### PR TITLE
Configurable number of lines of context, fixes #18

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -378,8 +378,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             // linesBefore & linesAfter are inclusive with the offending line.
             // if linesOfContext is even, there will be one extra line
             //   *before* the offending line.
-            // ProTip: ~~ == Math.floor()
-            linesBefore = ~~(TraceKit.linesOfContext / 2),
+            linesBefore = Math.floor(TraceKit.linesOfContext / 2),
             // Add one extra line if linesOfContext is odd
             linesAfter = linesBefore + (TraceKit.linesOfContext % 2),
             start = Math.max(0, line - linesBefore - 1),


### PR DESCRIPTION
Should be pretty self explanatory. Taking a configurable numer of lines to be grabbed for use in context, and some some calculations to determine how many lines to grab before and how many to grab after.

This will product something like this in different cases. It's preferable to have an odd number of lines so that the offending line can be centered.
##### 11 lines of context (5 before, bad line, 5 after)

```
1.
2.
3.
4.
5.
**BAD LINE**
7.
8.
9.
10.
11.
```
#### 4 lines of context (2 before, bad line, 1 after)

```
1.
2.
**BAD LINE**
4.
```
