### PR TITLE
Patch the right jQuery.ajax

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -1129,7 +1129,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
     };
 
     var _oldAjax = $.ajax;
-    $.fn.ajax = function traceKitAjaxWrapper(s) {
+    $.ajax = function traceKitAjaxWrapper(s) {
         if ($.isFunction(s.complete)) {
             var _oldComplete = s.complete;
             s.complete = function traceKitjQueryComplete() {


### PR DESCRIPTION
There is no $.fn.ajax, only $.ajax. This was adding a new .ajax property on all jQuery objects.
