### PR TITLE
Consolidate function wrapping into a TraceKit.wrap()

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -39,7 +39,7 @@ TraceKit._has = function _has(object, key) {
 TraceKit.wrap = function traceKitWrapper(func) {
     function wrapped() {
         try {
-            return fn.apply(this, arguments);
+            return func.apply(this, arguments);
         } catch (e) {
             TraceKit.report(e);
             throw e;


### PR DESCRIPTION
This removes a lot of duplicate code.
Refs #3 as well.
