### PR TITLE
Only install global error handler if we have at least one subscriber

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -106,6 +106,7 @@ TraceKit.report = (function reportModuleWrapper() {
      * @param {Function} handler
      */
     function subscribe(handler) {
+        installGlobalHandler();
         handlers.push(handler);
     }
 
@@ -145,7 +146,7 @@ TraceKit.report = (function reportModuleWrapper() {
         }
     }
 
-    var _oldOnerrorHandler = window.onerror;
+    var _oldOnerrorHandler;
 
     /**
      * Ensures all global unhandled exceptions are recorded.
@@ -155,7 +156,7 @@ TraceKit.report = (function reportModuleWrapper() {
      * @param {(number|string)} lineNo The line number at which the error
      * occurred.
      */
-    window.onerror = function traceKitWindowOnError(message, url, lineNo) {
+    function traceKitWindowOnError(message, url, lineNo) {
         var stack = null;
 
         if (lastExceptionStack) {
@@ -186,7 +187,16 @@ TraceKit.report = (function reportModuleWrapper() {
         }
 
         return false;
-    };
+    }
+
+    function installGlobalHandler ()
+    {
+        if (window.onerror === traceKitWindowOnError) {
+            return;
+        }
+        _oldOnerrorHandler = window.onerror;
+        window.onerror = traceKitWindowOnError;
+    }
 
     /**
      * Reports an unhandled Error to TraceKit.


### PR DESCRIPTION
This changes TraceKit to only install a window.onerror handler if we get a subscriber.

Even though the onerror handler is always necessary when catching exceptions for IE, there's no need for the handler if there are no exception handlers, since the exception would be ignored anyway.

Catching exceptions in development mode can be very annoying and can mess up debugging by changing backtraces to point to the last point where an exception has been rethrown, for example. For this reason, it's often easiest to not have any global exception handlers while debugging.

The way TraceKit was set up, this basically meant you were forced not to load in TraceKit code during debugging. This also then means that you'll get a lot of extra code in your production builds that you haven't tested in development.

With this change, TraceKit can still be loaded in development builds. If no subscriber is registered for handling exceptions, no global error handler will be installed, so debug builds can continue to work as normal.

Refers to #21 and #14.
