### PR TITLE
Make it optional to wrap jQuery or async callbacks

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -1058,7 +1058,8 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
  * Extends support for global error handling for asynchronous browser
  * functions. Adopted from Closure Library's errorhandler.js
  */
-(function extendToAsynchronousCallbacks() {
+TraceKit.wrapAsyncCallbacks = function  ()
+{
     var _helper = function _helper(fnName) {
         var originalFn = window[fnName];
         window[fnName] = function traceKitAsyncExtension() {
@@ -1081,13 +1082,15 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
 
     _helper('setTimeout');
     _helper('setInterval');
-}());
+};
 
 /**
  * Extended support for backtraces and global error handling for most
  * asynchronous jQuery functions.
  */
-(function traceKitAsyncForjQuery($) {
+TraceKit.wrapJQuery = function ()
+{
+    var $ = window.jQuery;
 
     // quit if jQuery isn't on the page
     if (!$) {
@@ -1141,8 +1144,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             throw e;
         }
     };
-
-}(window.jQuery));
+};
 
 //Default options:
 if (!TraceKit.remoteFetching) {


### PR DESCRIPTION
We have our own wrapper for asynchronous callbacks and jquery events, where we do stuff beside exception handling.

TraceKit interferes with this by wrapping these threads too, even though we already catch exceptions in these async handlers ourselves.

TraceKits' wrapping should be optional, so it doesn't interfere with wrappers you create yourself.

This patch disables the wrapping of both setTimeout & friends and jQuery entirely. They can be re-enabled by calling TraceKit.wrapJQuery() or TraceKit.wrapAsyncCallbacks().

Refers to #35.