### PR TITLE
if old onerror fn defined, let it choose to notify TraceKit handlers or not

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -180,11 +180,15 @@ TraceKit.report = (function reportModuleWrapper() {
             };
         }
 
-        notifyHandlers(stack, 'from window.onerror');
-
-        if (_oldOnerrorHandler) {
-            return _oldOnerrorHandler.apply(this, arguments);
+        function notifyHandlersWrapper() {
+            notifyHandlers(stack, 'from window.onerror');
         }
+        if (_oldOnerrorHandler) {
+            var args = Array.prototype.slice.call(arguments);
+            args.push(notifyHandlersWrapper);
+            return _oldOnerrorHandler.apply(this, args);
+        }
+        notifyHandlersWrapper();
 
         return false;
     }


### PR DESCRIPTION
Closes #43
