### PR TITLE
Change to comply with closure compiler ES5 strict mode

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -322,7 +322,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             return '';
         }
         try {
-            function getXHR() {
+            getXHR = function() {
                 try {
                     return new window.XMLHttpRequest();
                 } catch (e) {


### PR DESCRIPTION
To not have to force compilation with ES5 strict mode in the closure compiler I propose the following change
