### PR TITLE
Removed default option checks and added global handling flag.

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -106,7 +106,9 @@ TraceKit.report = (function reportModuleWrapper() {
      * @param {Function} handler
      */
     function subscribe(handler) {
-        installGlobalHandler();
+        if (TraceKit.globalHandling) {
+          installGlobalHandler();
+        }
         handlers.push(handler);
     }
 
@@ -1092,19 +1094,11 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
     _helper('setInterval');
 }());
 
-//Default options:
-if (!TraceKit.remoteFetching) {
-  TraceKit.remoteFetching = true;
-}
-if (!TraceKit.collectWindowErrors) {
-  TraceKit.collectWindowErrors = true;
-}
-if (!TraceKit.linesOfContext || TraceKit.linesOfContext < 1) {
-  // 5 lines before, the offending line, 5 lines after
-  TraceKit.linesOfContext = 11;
-}
-
-
+// Default options:
+TraceKit.globalHandling = true;
+TraceKit.remoteFetching = true;
+TraceKit.collectWindowErrors = true;
+TraceKit.linesOfContext = 11;
 
 // Export to global object
 window.TraceKit = TraceKit;

--- a/tracekit.js
+++ b/tracekit.js
@@ -206,7 +206,7 @@ TraceKit.report = (function reportModuleWrapper() {
         var args = _slice.call(arguments, 1);
         if (lastExceptionStack) {
             if (lastException === ex) {
-                throw ex; // already caught by an inner catch block, ignore
+                throw ex; // rethrow.
             } else {
                 var s = lastExceptionStack;
                 lastExceptionStack = null;

--- a/tracekit.js
+++ b/tracekit.js
@@ -107,7 +107,7 @@ TraceKit.report = (function reportModuleWrapper() {
      */
     function subscribe(handler) {
         if (TraceKit.globalHandling) {
-          installGlobalHandler();
+              installGlobalHandler();
         }
         handlers.push(handler);
     }
@@ -128,11 +128,8 @@ TraceKit.report = (function reportModuleWrapper() {
      * Dispatch stack information to all handlers.
      * @param {Object.<string, *>} stack
      */
-    function notifyHandlers(stack, windowError) {
+    function notifyHandlers(stack) {
         var exception = null;
-        if (windowError && !TraceKit.collectWindowErrors) {
-          return;
-        }
         for (var i in handlers) {
             if (_has(handlers, i)) {
                 try {
@@ -182,7 +179,7 @@ TraceKit.report = (function reportModuleWrapper() {
             };
         }
 
-        notifyHandlers(stack, 'from window.onerror');
+        notifyHandlers(stack);
 
         if (_oldOnerrorHandler) {
             return _oldOnerrorHandler.apply(this, arguments);
@@ -209,7 +206,7 @@ TraceKit.report = (function reportModuleWrapper() {
         var args = _slice.call(arguments, 1);
         if (lastExceptionStack) {
             if (lastException === ex) {
-                return; // already caught by an inner catch block, ignore
+                throw ex; // already caught by an inner catch block, ignore
             } else {
                 var s = lastExceptionStack;
                 lastExceptionStack = null;
@@ -1094,10 +1091,9 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
     _helper('setInterval');
 }());
 
-// Default options:
+//Default options:
 TraceKit.globalHandling = true;
 TraceKit.remoteFetching = true;
-TraceKit.collectWindowErrors = true;
 TraceKit.linesOfContext = 11;
 
 // Export to global object


### PR DESCRIPTION
The default option checks are unnecessary and it is arguable if it is even an optimization, but does add more lines of code and complexity.

Also, there should be a global handling flag as sometimes we do not want exceptions to be reported from the event handler. For example, certain exception reporting functions may assume there is an options parameter passed in which the global handler doesn't provide. Also, I may not have looked at it thoroughly enough, but it seems like exceptions that are reported with TraceKit.report(e) are re-thrown to the global handler resulting in a duplicate error logging? 
