### PR TITLE
add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
     },
     "scripts": {
         "test": "grunt --verbose travis"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/occ/TraceKit.git"
     }
 }


### PR DESCRIPTION
The additional repository information makes npm happy.
(installing through npm is useful when using [browserify](https://github.com/substack/node-browserify))