### PR TITLE
Use window onerror exception object if provided

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -156,10 +156,12 @@ TraceKit.report = (function reportModuleWrapper() {
      * @param {(number|string)} lineNo The line number at which the error
      * occurred.
      */
-    function traceKitWindowOnError(message, url, lineNo) {
+    function traceKitWindowOnError(message, url, lineNo, column, ex) {
         var stack = null;
 
-        if (lastExceptionStack) {
+         if (ex) {
+            stack = TraceKit.computeStackTrace(ex);
+        } else if (lastExceptionStack) {
             TraceKit.computeStackTrace.augmentStackTraceWithInitialElement(lastExceptionStack, url, lineNo, message);
             stack = lastExceptionStack;
             lastExceptionStack = null;


### PR DESCRIPTION
Chrome provides an exception object for window.onerror that should be used instead of guessing. http://stackoverflow.com/questions/17687410/when-will-proper-stack-traces-be-provided-on-window-onerror-function
