### PR TITLE
Add colon to regex after file|http|https match to avoid mismatches where...

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -619,7 +619,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
         }
 
         var chrome = /^\s*at (?:((?:\[object object\])?\S+(?: \[as \S+\])?) )?\(?((?:file|http|https):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
-            gecko = /^\s*(\S*)(?:\((.*?)\))?@((?:file|http|https).*?):(\d+)(?::(\d+))?\s*$/i,
+            gecko = /^\s*(\S*)(?:\((.*?)\))?@((?:file|http|https):.*?):(\d+)(?::(\d+))?\s*$/i,
             lines = ex.stack.split('\n'),
             stack = [],
             parts,


### PR DESCRIPTION
... site domain contains the string 'file'