### PR TITLE
TraceKit can't handle exceptions on windows phone 8 in cordova.

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -350,7 +350,9 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             // URL needs to be able to fetched within the acceptable domain.  Otherwise,
             // cross-domain errors will be triggered.
             var source = '';
-            if (url.indexOf(document.domain) !== -1) {
+            var domain = '';
+            try { domain = document.domain; } catch (e) {}
+            if (url.indexOf(domain) !== -1) {
                 source = loadSource(url);
             }
             sourceCache[url] = source ? source.split('\n') : [];


### PR DESCRIPTION
As soon as document.domain is accessed it throws and exception under WP8 in cordova with:

> Unspecified Error

This will silence any error caused by accessing `document.domain` and allow the sources to be fetched.
