### PR TITLE
Expose getSource as TraceKit.computeStackTrace.getSource

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -1059,6 +1059,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
     computeStackTrace.guessFunctionName = guessFunctionName;
     computeStackTrace.gatherContext = gatherContext;
     computeStackTrace.ofCaller = computeStackTraceOfCaller;
+    computeStackTrace.getSource = getSource;
 
     return computeStackTrace;
 }());


### PR DESCRIPTION
Hi @occ, this commit is necessary to enable sharing of the source code cache between TraceKit and other running code.
